### PR TITLE
Some small improvements

### DIFF
--- a/app/views/hooks/_issue_hook.html.erb
+++ b/app/views/hooks/_issue_hook.html.erb
@@ -1,4 +1,4 @@
-<% if project.present? && project.release_log_enabled? && issue.present? %>
+<% if ReleaseLogEntry.for_issue(issue).count > 0 %>
     <hr />
     <p>
         <strong><%= release_logs_label_for(:release_log) %></strong>

--- a/app/views/release_log_entries/_issue_release_log.html.erb
+++ b/app/views/release_log_entries/_issue_release_log.html.erb
@@ -5,6 +5,6 @@
     <%= format_time release_log.released_at %>
     <%= issue_failed_release_info(release_log).html_safe %> -
     <strong>
-        <%= link_to release_log.id, release_log_path(release_log, :project_id => release_log.project.identifier), :target => '_blank' %>
+        <%= link_to release_log.title, release_log_path(release_log, :project_id => release_log.project.identifier), :target => '_blank' %>
     </strong>
 </div>

--- a/app/views/release_log_entries/_issue_release_log.html.erb
+++ b/app/views/release_log_entries/_issue_release_log.html.erb
@@ -5,6 +5,6 @@
     <%= format_time release_log.released_at %>
     <%= issue_failed_release_info(release_log).html_safe %> -
     <strong>
-        <%= link_to release_log.id, release_log_path(release_log, :project_id => project.identifier), :target => '_blank' %>
+        <%= link_to release_log.id, release_log_path(release_log, :project_id => release_log.project.identifier), :target => '_blank' %>
     </strong>
 </div>

--- a/app/views/release_logs/show.html.erb
+++ b/app/views/release_logs/show.html.erb
@@ -6,7 +6,7 @@
    can_manage = User.current.allowed_to?(:manage_project_release_logs, @project)
 %>
 
-<h2><%= @release_log.title %> - <%= @release_log.id %> - <%= @release_log.status.titleize %></h2>
+<h2><%= @release_log.title %> - <%= @release_log.status.titleize %></h2>
 
 <div class="details">
     <% if can_manage %>

--- a/assets/javascripts/release-logs.js
+++ b/assets/javascripts/release-logs.js
@@ -67,7 +67,7 @@ jQuery(document).ready(function () {
             {
                 select: function (event, object) {
                     var $noteElement = $('#new_release_log_entry_note_' + counter);
-                    $noteElement.val('h4. ' + object.item.label + '\n\n' + $noteElement.val());
+                    $noteElement.val(object.item.label + '\n\n' + $noteElement.val());
                 }
             }
         );
@@ -87,7 +87,7 @@ jQuery(document).ready(function () {
             {
                 select: function (event, object) {
                     var $noteElement = $('#new_release_log_entry_note_' + $element.data('index'));
-                    $noteElement.val('h4. ' + object.item.label + '\n\n' + $noteElement.val());
+                    $noteElement.val(object.item.label + '\n\n' + $noteElement.val());
                 }
             }
         );


### PR DESCRIPTION
1. Allow for better cross-project release logs. Useful if working with subprojects. In the original code, on the issue page there is a check if the current project has release logs configured. So even if the current issue is in the release of another project, it will not display the release log block for the issue.
2. Release log ID is not really meaningful. Remove the release log ID from the release log page. On the issue page, the link is the title of the release log instead of the ID.
3. Remove the 'h4' from release log notes. Especially useless if using the rich text editor for text fields.
