### PR TITLE
Increment in 5 minute intervals for available release minutes

### DIFF
--- a/app/views/release_logs/_form.html.erb
+++ b/app/views/release_logs/_form.html.erb
@@ -65,7 +65,7 @@
                            :no_label => true %>
             <%= select_tag :release_minutes,
                            options_for_select(
-                                   (0..59).to_a.map { |minute| [minute.to_s.rjust(2, '0'), minute] },
+                                   (0..59).step(5).map { |minute| [minute.to_s.rjust(2, '0'), minute] },
                                    :selected => released_at.try(:min)),
                            :include_blank => true,
                            :no_label => true %>


### PR DESCRIPTION
Because I think that the 1 minute accuracy is overkill.

Also the `step` method returns an Enumerator no need to call .to_a before map, [related documentation](http://ruby-doc.org/core-1.9.3/Range.html#method-i-step)
